### PR TITLE
Remove bundled logo asset and clarify packaging instructions

### DIFF
--- a/theme/arc-duality-theme/README.md
+++ b/theme/arc-duality-theme/README.md
@@ -1,0 +1,51 @@
+# ARC Duality Shopify Theme
+
+The **ARC Duality** theme is a bespoke Online Store 2.0 build for Alison Resin Creations. It blends luminous storytelling with modern UX touches including synchronized light/dark theming, custom sections, and polished defaults tailored to ARC's brand palette.
+
+## What's inside
+
+- Production-ready theme files under `arc-duality-theme/` with modular sections (hero, featured grid, story highlights, gallery media, rich text, collapsible FAQs, contact form, collection + product layouts).
+- Palette-aware `base.css` with CSS custom properties and responsive styling.
+- `theme.js` handles theme mode toggling (localStorage + system preference), cart badge syncing, announcement dismissal, and accessibility enhancements.
+- Configured `settings_schema.json`/`settings_data.json` so the theme looks polished immediately after upload.
+- Localized copy in `locales/en.default.json` with ARC-specific voice.
+
+## How to use
+
+1. **Prep the brand asset**
+   - The production archive should include ARC's logo at `assets/arc-logo.png`.
+   - Copy the existing source image (from the repository root) before zipping:
+     ```bash
+     cp resources/images/ARC-Logo.png theme/arc-duality-theme/assets/arc-logo.png
+     ```
+
+2. **Zip & upload**
+   - From the repository root run:
+     ```bash
+     cd theme
+     zip -r arc-duality-theme.zip arc-duality-theme
+     ```
+   - This creates `theme/arc-duality-theme.zip`, which you can then upload in Shopify under **Online Store → Themes → Upload theme**.
+
+3. **Configure settings**
+   - From the theme editor adjust brand colours, announcement text, navigation menu, and footer links.
+   - Add social links (Instagram, Facebook, TikTok) under **Theme settings → Global socials** to expose header icons.
+
+4. **Enable dark mode**
+   - Dark mode is on by default and syncs with system preferences. You can disable the toggle or set a fixed default via **Theme settings → Theme modes**.
+
+5. **Customize content**
+   - Home page defaults to Hero → Featured Grid → Story Highlights → Gallery Media. Swap sections, connect collections, and add media/video blocks as needed.
+   - Product templates include a metafield callout for `custom.quote`. Populate it from **Product metafields** to surface special messaging.
+
+6. **Contact & FAQs**
+   - Page templates are pre-configured for Gallery, About, FAQ, Terms, Privacy, and Contact pages. Assign these templates from the page settings in Shopify to reuse ARC copy and sections.
+
+## Assets
+
+- Copy `resources/images/ARC-Logo.png` into `arc-duality-theme/assets/arc-logo.png` before packaging so header and footer logos render.
+- Base palette values are defined as CSS variables; override them via theme settings if needed.
+
+## Need help?
+
+For adjustments beyond theme settings (new sections, metafields, etc.), duplicate the theme in Shopify and iterate safely. The structure follows Shopify OS 2.0 best practices, so extending via additional sections/snippets should feel familiar.

--- a/theme/arc-duality-theme/assets/base.css
+++ b/theme/arc-duality-theme/assets/base.css
@@ -1,0 +1,651 @@
+:root {
+  --font-family-base: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --arc-bg: #ffffff;
+  --arc-surface: #f7f4ef;
+  --arc-gold: #c9a646;
+  --arc-gold-dark: #a3832d;
+  --arc-text: #2d2a26;
+  --arc-muted: #6b655f;
+  --arc-accent-black: #1f1b16;
+  --arc-ivory: #f4ede3;
+  --arc-border-radius: 12px;
+  --arc-transition: 200ms ease;
+  --arc-max-width: 1200px;
+}
+
+[data-theme="dark"] {
+  --arc-bg: #14110d;
+  --arc-surface: #1f1b16;
+  --arc-text: #f4ede3;
+  --arc-muted: #c9c1b3;
+  --arc-accent-black: #f4ede3;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  color: var(--arc-text);
+  background: var(--arc-bg);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--arc-gold-dark);
+  text-decoration: none;
+  transition: color var(--arc-transition);
+}
+
+a:hover,
+a:focus {
+  color: var(--arc-gold);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: var(--arc-border-radius);
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  background: var(--arc-gold);
+  color: var(--arc-accent-black);
+  transition: background var(--arc-transition), color var(--arc-transition), transform var(--arc-transition);
+}
+
+button:hover,
+button:focus {
+  background: var(--arc-gold-dark);
+  color: var(--arc-ivory);
+  transform: translateY(-1px);
+}
+
+.skip-to-content {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--arc-gold);
+  color: var(--arc-accent-black);
+  padding: 0.75rem 1.5rem;
+  z-index: 2000;
+}
+
+.skip-to-content:focus {
+  left: 1rem;
+}
+
+.wrapper {
+  width: min(100% - 2rem, var(--arc-max-width));
+  margin: 0 auto;
+}
+
+header.site-header {
+  background: var(--arc-surface);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  backdrop-filter: blur(12px);
+}
+
+.site-header__inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 0;
+}
+
+.site-header__branding {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.site-header__branding img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: 8px;
+  background: var(--arc-bg);
+  padding: 0.25rem;
+}
+
+.site-header__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.site-nav a {
+  font-weight: 500;
+  color: var(--arc-text);
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  transition: background var(--arc-transition), color var(--arc-transition);
+}
+
+.site-nav a:hover,
+.site-nav a:focus,
+.site-nav a[aria-current="page"] {
+  background: rgba(201, 166, 70, 0.15);
+  color: var(--arc-accent-black);
+}
+
+.utility-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: var(--arc-bg);
+  color: var(--arc-text);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.theme-toggle svg {
+  width: 20px;
+  height: 20px;
+}
+
+.cart-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--arc-bg);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: var(--arc-text);
+}
+
+.cart-count {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: var(--arc-gold);
+  color: var(--arc-accent-black);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  padding: 0 0.35rem;
+  min-width: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.announcement-bar {
+  background: var(--arc-gold);
+  color: var(--arc-accent-black);
+  padding: 0.5rem 0;
+  text-align: center;
+}
+
+main {
+  background: var(--arc-bg);
+}
+
+.section {
+  padding: 3rem 0;
+}
+
+.section--surface {
+  background: var(--arc-surface);
+}
+
+.section__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.section__title {
+  font-size: 2rem;
+  margin: 0 0 0.5rem;
+}
+
+.section__description {
+  margin: 0 auto;
+  max-width: 50ch;
+  color: var(--arc-muted);
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero__heading {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  margin: 0;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.hero__actions a.primary {
+  background: var(--arc-gold);
+  color: var(--arc-accent-black);
+}
+
+.hero__actions a.secondary {
+  border: 1px solid currentColor;
+  color: var(--arc-text);
+}
+
+.product-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.product-card {
+  border-radius: var(--arc-border-radius);
+  overflow: hidden;
+  background: var(--arc-surface);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 30px rgba(31, 27, 22, 0.08);
+  transition: transform var(--arc-transition), box-shadow var(--arc-transition);
+}
+
+.product-card:hover,
+.product-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 40px rgba(31, 27, 22, 0.12);
+}
+
+.product-card__media {
+  aspect-ratio: 4 / 5;
+  background: var(--arc-bg);
+}
+
+.product-card__info {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-card__title {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.product-card__price {
+  font-weight: 600;
+}
+
+.swatch-list {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: var(--arc-surface);
+}
+
+.footer {
+  background: var(--arc-surface);
+  color: var(--arc-text);
+  padding: 3rem 0;
+}
+
+.footer__inner {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer__socials {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.footer__socials a {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(201, 166, 70, 0.15);
+  color: var(--arc-accent-black);
+}
+
+.notice {
+  padding: 1rem;
+  border-radius: var(--arc-border-radius);
+  background: rgba(201, 166, 70, 0.15);
+  color: var(--arc-accent-black);
+}
+
+.collapsible {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: var(--arc-border-radius);
+  overflow: hidden;
+}
+
+.collapsible__item + .collapsible__item {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.collapsible__trigger {
+  width: 100%;
+  text-align: left;
+  background: none;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.collapsible__content {
+  padding: 0 1.25rem 1rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--arc-border-radius);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: var(--arc-bg);
+  color: var(--arc-text);
+}
+
+.contact-form button {
+  justify-self: start;
+}
+
+.video-wrapper {
+  border-radius: var(--arc-border-radius);
+  overflow: hidden;
+  background: var(--arc-surface);
+}
+
+.video-wrapper video {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.header-socials {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.header-socials a {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(201, 166, 70, 0.18);
+  color: var(--arc-accent-black);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.story-highlights {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.story-highlight {
+  background: var(--arc-surface);
+  border-radius: var(--arc-border-radius);
+  padding: 1.5rem;
+  text-align: center;
+  box-shadow: 0 12px 28px rgba(31, 27, 22, 0.08);
+}
+
+.story-highlight__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 0.75rem;
+  border-radius: 50%;
+  background: rgba(201, 166, 70, 0.2);
+  font-size: 1.5rem;
+}
+
+.gallery-media-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.gallery-media-item {
+  background: var(--arc-surface);
+  border-radius: var(--arc-border-radius);
+  overflow: hidden;
+  box-shadow: 0 12px 30px rgba(31, 27, 22, 0.08);
+}
+
+.gallery-media-product {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+  height: 100%;
+}
+
+.gallery-media-thumb {
+  aspect-ratio: 4 / 3;
+  background: var(--arc-bg);
+}
+
+.gallery-media-caption {
+  padding: 1rem 1.25rem 1.5rem;
+}
+
+.gallery-media-caption h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.product__inner {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.product__gallery {
+  display: grid;
+  gap: 1rem;
+}
+
+.product__media {
+  border-radius: var(--arc-border-radius);
+  overflow: hidden;
+  background: var(--arc-surface);
+}
+
+.product__details {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.product__title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+}
+
+.product__price {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.product__quote {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--arc-gold);
+  background: rgba(201, 166, 70, 0.15);
+  border-radius: var(--arc-border-radius);
+  font-style: italic;
+}
+
+.product__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.product__form select,
+.product__form input[type="number"] {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--arc-border-radius);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: var(--arc-bg);
+  color: var(--arc-text);
+}
+
+.product__share ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.product__extra {
+  display: grid;
+  gap: 1rem;
+}
+
+.product__extra-block details {
+  background: var(--arc-surface);
+  border-radius: var(--arc-border-radius);
+  padding: 1rem 1.25rem;
+}
+
+.collection__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.collection__filters {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 2rem;
+}
+
+.collection__filter-group ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.collection__filter-group a {
+  display: inline-flex;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(201, 166, 70, 0.12);
+  color: inherit;
+}
+
+.footer__bottom {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--arc-muted);
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+@media (max-width: 900px) {
+  .site-header__inner {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .site-header__branding {
+    justify-content: center;
+  }
+
+  .utility-actions {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/theme/arc-duality-theme/assets/theme.js
+++ b/theme/arc-duality-theme/assets/theme.js
@@ -1,0 +1,152 @@
+(function () {
+  const body = document.body;
+  const allowDark = body.dataset.themeAllowDark === 'true';
+  const autoSync = body.dataset.themeAuto === 'true';
+  const defaultMode = body.dataset.theme || 'light';
+  const STORAGE_KEY = 'arc-theme-mode';
+  const root = document.documentElement;
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function getStoredMode() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function storeMode(mode) {
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch (e) {
+      /* noop */
+    }
+  }
+
+  function applyMode(mode) {
+    if (!allowDark) {
+      mode = 'light';
+    }
+    root.setAttribute('data-theme', mode);
+    body.setAttribute('data-theme', mode);
+    const toggle = document.querySelector('[data-theme-toggle]');
+    if (toggle) {
+      toggle.setAttribute('aria-pressed', mode === 'dark');
+      const label = mode === 'dark' ? toggle.dataset.labelLight : toggle.dataset.labelDark;
+      if (label) {
+        toggle.querySelector('[data-theme-toggle-label]').textContent = label;
+      }
+    }
+  }
+
+  function resolveMode() {
+    if (!allowDark) {
+      return 'light';
+    }
+    const stored = getStoredMode();
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    if (autoSync) {
+      return prefersDark.matches ? 'dark' : 'light';
+    }
+    return defaultMode;
+  }
+
+  function toggleMode() {
+    if (!allowDark) {
+      return;
+    }
+    const current = root.getAttribute('data-theme') || resolveMode();
+    const next = current === 'dark' ? 'light' : 'dark';
+    applyMode(next);
+    storeMode(next);
+  }
+
+  applyMode(resolveMode());
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.querySelector('[data-theme-toggle]');
+    if (toggle) {
+      toggle.addEventListener('click', toggleMode);
+      toggle.addEventListener('keydown', function (event) {
+        if (event.key === ' ' || event.key === 'Enter') {
+          event.preventDefault();
+          toggleMode();
+        }
+      });
+    }
+
+    const skip = document.querySelector('.skip-to-content');
+    if (skip) {
+      skip.addEventListener('click', function (event) {
+        const target = document.getElementById(skip.getAttribute('href').replace('#', ''));
+        if (target) {
+          target.setAttribute('tabindex', '-1');
+          target.focus({ preventScroll: false });
+        }
+      });
+    }
+
+    const announcement = document.querySelector('[data-announcement]');
+    if (announcement) {
+      const id = announcement.dataset.announcement;
+      const dismissKey = `announcement-dismissed-${id}`;
+      const dismissButton = announcement.querySelector('[data-announcement-dismiss]');
+      if (dismissButton) {
+        try {
+          if (localStorage.getItem(dismissKey)) {
+            announcement.setAttribute('hidden', 'hidden');
+          }
+        } catch (e) {
+          /* noop */
+        }
+        dismissButton.addEventListener('click', function () {
+          announcement.setAttribute('hidden', 'hidden');
+          try {
+            localStorage.setItem(dismissKey, 'true');
+          } catch (e) {
+            /* noop */
+          }
+        });
+      }
+    }
+
+    updateCartCount();
+  });
+
+  if (allowDark && autoSync) {
+    prefersDark.addEventListener('change', function (event) {
+      const stored = getStoredMode();
+      if (stored === null) {
+        applyMode(event.matches ? 'dark' : 'light');
+      }
+    });
+  }
+
+  function updateCartCount(count) {
+    const cartCountElements = document.querySelectorAll('[data-cart-count]');
+    if (!cartCountElements.length) return;
+
+    let value = typeof count === 'number' ? count : null;
+    if (value === null && window.Shopify && window.Shopify.theme) {
+      value = window.Shopify.theme.cartCount;
+    }
+    cartCountElements.forEach(function (el) {
+      if (value && value > 0) {
+        el.textContent = value;
+        el.hidden = false;
+      } else {
+        el.textContent = '0';
+        el.hidden = true;
+      }
+    });
+  }
+
+  document.addEventListener('cart:refresh', function (event) {
+    var detail = event && event.detail;
+    var cart = detail && detail.cart;
+    var count = cart ? cart.item_count : null;
+    updateCartCount(count);
+  });
+})();

--- a/theme/arc-duality-theme/config/settings_data.json
+++ b/theme/arc-duality-theme/config/settings_data.json
@@ -1,0 +1,104 @@
+{
+  "current": "Default",
+  "theme_store_id": null,
+  "presets": {
+    "Default": {
+      "settings": {
+        "enable_dark_mode": true,
+        "theme_mode_default": "light",
+        "theme_mode_auto": true,
+        "color_background": "#ffffff",
+        "color_surface": "#f7f4ef",
+        "color_gold": "#c9a646",
+        "color_gold_dark": "#a3832d",
+        "color_text": "#2d2a26",
+        "color_muted": "#6b655f",
+        "enable_social_icons": true,
+        "social_instagram": "https://www.instagram.com/alisonresincreations",
+        "social_facebook": "https://www.facebook.com/alisonresincreations"
+      },
+      "sections": {
+        "header": {
+          "type": "header",
+          "settings": {
+            "store_name": "Alison Resin Creations",
+            "tagline": "Resin artistry for whimsical hearts",
+            "announcement_enable": true,
+            "announcement_text": "Complimentary gift wrapping on every ARC Duality order",
+            "announcement_dismissible": true
+          }
+        },
+        "footer": {
+          "type": "footer",
+          "settings": {
+            "brand_blurb": "ARC Duality celebrates the magic of light and story. Each resin keepsake is poured in small batches, finished by hand, and made to make your heart glow.",
+            "shop_heading": "Shop Alison Resin Creations",
+            "policy_heading": "Need to Know",
+            "footer_copyright": "Alison Resin Creations"
+          },
+          "blocks": {
+            "social-1": {
+              "type": "social",
+              "settings": {
+                "label": "Instagram",
+                "url": "https://www.instagram.com/alisonresincreations"
+              }
+            },
+            "social-2": {
+              "type": "social",
+              "settings": {
+                "label": "Facebook",
+                "url": "https://www.facebook.com/alisonresincreations"
+              }
+            }
+          },
+          "block_order": [
+            "social-1",
+            "social-2"
+          ]
+        },
+        "hero": {
+          "type": "hero-arc",
+          "settings": {
+            "heading": "Whimsical Resin Worlds, Poured with Heart",
+            "body": "ARC Duality is Alison's story-led collection of luminous resin keepsakes—miniature villages, balloon adventures, and woodland wonders poured with care.",
+            "primary_label": "Shop Resin Keepsakes",
+            "primary_link": "/collections/all",
+            "secondary_label": "View the Gallery",
+            "secondary_link": "/pages/gallery",
+            "notice": "Made-to-order commissions now open for summer weddings."
+          }
+        },
+        "featured": {
+          "type": "featured-arc-grid",
+          "settings": {
+            "heading": "Collector Favourites",
+            "subheading": "A glow-filled selection of hand-poured keepsakes currently lighting up living rooms across the UK.",
+            "products_to_show": 4,
+            "show_swatches": true
+          }
+        },
+        "stories": {
+          "type": "story-highlights",
+          "settings": {
+            "heading": "Why ARC Duality Shines",
+            "subheading": "Each piece balances soft storytelling with sparkling detail."
+          }
+        },
+        "gallery": {
+          "type": "gallery-media",
+          "settings": {
+            "heading": "Step Into the Studio",
+            "subheading": "Swap clips and product highlights to share the artistry behind every pour."
+          }
+        }
+      },
+      "order": [
+        "hero",
+        "featured",
+        "stories",
+        "gallery"
+      ]
+    }
+  }
+}

--- a/theme/arc-duality-theme/config/settings_schema.json
+++ b/theme/arc-duality-theme/config/settings_schema.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "Brand",
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "brand_logo",
+        "label": "Default logo"
+      },
+      {
+        "type": "color",
+        "id": "color_background",
+        "label": "Background color",
+        "default": "#ffffff"
+      },
+      {
+        "type": "color",
+        "id": "color_surface",
+        "label": "Surface color",
+        "default": "#f7f4ef"
+      },
+      {
+        "type": "color",
+        "id": "color_gold",
+        "label": "Primary gold",
+        "default": "#c9a646"
+      },
+      {
+        "type": "color",
+        "id": "color_gold_dark",
+        "label": "Deep gold",
+        "default": "#a3832d"
+      },
+      {
+        "type": "color",
+        "id": "color_text",
+        "label": "Body text",
+        "default": "#2d2a26"
+      },
+      {
+        "type": "color",
+        "id": "color_muted",
+        "label": "Muted text",
+        "default": "#6b655f"
+      }
+    ]
+  },
+  {
+    "name": "Theme modes",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_dark_mode",
+        "label": "Enable dark mode",
+        "default": true
+      },
+      {
+        "type": "select",
+        "id": "theme_mode_default",
+        "label": "Default theme mode",
+        "default": "light",
+        "options": [
+          {
+            "value": "light",
+            "label": "Light"
+          },
+          {
+            "value": "dark",
+            "label": "Dark"
+          }
+        ]
+      },
+      {
+        "type": "checkbox",
+        "id": "theme_mode_auto",
+        "label": "Sync with system preference",
+        "default": true
+      }
+    ]
+  },
+  {
+    "name": "Global socials",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_social_icons",
+        "label": "Display social icons in header",
+        "default": true
+      },
+      {
+        "type": "url",
+        "id": "social_instagram",
+        "label": "Instagram URL"
+      },
+      {
+        "type": "url",
+        "id": "social_facebook",
+        "label": "Facebook URL"
+      },
+      {
+        "type": "url",
+        "id": "social_tiktok",
+        "label": "TikTok URL"
+      }
+    ]
+  }
+]

--- a/theme/arc-duality-theme/layout/theme.liquid
+++ b/theme/arc-duality-theme/layout/theme.liquid
@@ -1,0 +1,33 @@
+<!doctype html>
+<html class="no-js" lang="{{ request.locale.iso_code }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page_title | escape }}</title>
+  <meta name="description" content="{{ page_description | escape }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  {{ 'base.css' | asset_url | stylesheet_tag }}
+  <style>
+    :root {
+      --arc-bg: {{ settings.color_background | default: '#ffffff' }};
+      --arc-surface: {{ settings.color_surface | default: '#f7f4ef' }};
+      --arc-gold: {{ settings.color_gold | default: '#c9a646' }};
+      --arc-gold-dark: {{ settings.color_gold_dark | default: '#a3832d' }};
+      --arc-text: {{ settings.color_text | default: '#2d2a26' }};
+      --arc-muted: {{ settings.color_muted | default: '#6b655f' }};
+    }
+  </style>
+  {{ content_for_header }}
+</head>
+<body data-theme="{{ settings.theme_mode_default | default: 'light' }}" data-theme-allow-dark="{{ settings.enable_dark_mode }}" data-theme-auto="{{ settings.theme_mode_auto }}">
+  <a class="skip-to-content" href="#MainContent">{{ 'general.accessibility.skip_to_content' | t }}</a>
+  {% section 'header' %}
+  <main id="MainContent" role="main">
+    {{ content_for_layout }}
+  </main>
+  {% section 'footer' %}
+  {{ 'theme.js' | asset_url | script_tag }}
+</body>
+</html>

--- a/theme/arc-duality-theme/locales/en.default.json
+++ b/theme/arc-duality-theme/locales/en.default.json
@@ -1,0 +1,67 @@
+{
+  "general": {
+    "accessibility": {
+      "skip_to_content": "Skip to content"
+    }
+  },
+  "sections": {
+    "header": {
+      "announcement_dismiss": "Dismiss announcement",
+      "home_link_label": "Back to home",
+      "logo_alt": "{{ shop_name }} logo",
+      "navigation_aria": "Primary navigation",
+      "nav_home": "Home",
+      "nav_gallery": "Gallery",
+      "nav_shop": "Shop",
+      "nav_about": "About",
+      "nav_faq": "FAQ",
+      "nav_terms": "Terms",
+      "nav_privacy": "Privacy",
+      "nav_contact": "Contact",
+      "nav_cart": "Cart",
+      "mode_light": "Light mode",
+      "mode_dark": "Dark mode",
+      "mode_toggle": "Toggle colour mode",
+      "cart": "View cart"
+    },
+    "featured_arc_grid": {
+      "empty": "Add a collection to showcase Alison's resin creations here."
+    },
+    "footer": {
+      "logo_alt": "{{ shop_name }} logo",
+      "default_shop": "Shop all keepsakes",
+      "default_faq": "Frequently asked questions",
+      "default_terms": "Terms & conditions",
+      "default_privacy": "Privacy policy",
+      "rights": "All rights reserved."
+    },
+    "contact_form": {
+      "success": "Thank you for reaching out. We'll reply soon!",
+      "name": "Name",
+      "email": "Email",
+      "phone": "Phone",
+      "message": "How can we help?"
+    },
+    "main_product": {
+      "share_label": "Share this story"
+    },
+    "main_collection": {
+      "filter_tags": "Filter by tag",
+      "filter_colors": "Filter by colour",
+      "empty": "No resin keepsakes found in this collection yet."
+    }
+  },
+  "products": {
+    "product": {
+      "add_to_cart": "Add to cart",
+      "sold_out": "Sold out",
+      "no_image": "Image coming soon",
+      "quantity": "Quantity"
+    }
+  },
+  "snippets": {
+    "media_video": {
+      "fallback": "Your browser does not support the video tag."
+    }
+  }
+}

--- a/theme/arc-duality-theme/sections/collapsible-content.liquid
+++ b/theme/arc-duality-theme/sections/collapsible-content.liquid
@@ -1,0 +1,90 @@
+<section class="section" id="Collapsible-{{ section.id }}">
+  <div class="wrapper">
+    {% if section.settings.heading != blank %}
+      <div class="section__header">
+        <h2 class="section__title">{{ section.settings.heading }}</h2>
+      </div>
+    {% endif %}
+    <div class="collapsible">
+      {% for block in section.blocks %}
+        <div class="collapsible__item" {{ block.shopify_attributes }}>
+          <button class="collapsible__trigger" type="button" aria-expanded="false" aria-controls="CollapsiblePanel-{{ block.id }}">
+            <span>{{ block.settings.title }}</span>
+            <span aria-hidden="true" data-collapsible-icon>+</span>
+          </button>
+          <div id="CollapsiblePanel-{{ block.id }}" class="collapsible__content" hidden>
+            {{ block.settings.content }}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('#Collapsible-{{ section.id }} .collapsible__trigger').forEach(function (trigger) {
+      trigger.addEventListener('click', function () {
+        var content = trigger.parentElement.querySelector('.collapsible__content');
+        var expanded = trigger.getAttribute('aria-expanded') === 'true';
+        trigger.setAttribute('aria-expanded', !expanded);
+        content.toggleAttribute('hidden');
+        var icon = trigger.querySelector('[data-collapsible-icon]');
+        if (icon) {
+          icon.textContent = expanded ? '+' : '−';
+        }
+      });
+    });
+  });
+</script>
+
+{% schema %}
+{
+  "name": "Collapsible content",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Questions answered"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "item",
+      "name": "Item",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "What makes ARC pieces special?"
+        },
+        {
+          "type": "richtext",
+          "id": "content",
+          "label": "Content",
+          "default": "<p>Each resin scene is layered over several pours, allowing Alison to embed miniature worlds, glowing lights, and custom messages.</p>"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Collapsible content",
+      "blocks": [
+        {
+          "type": "item"
+        },
+        {
+          "type": "item",
+          "settings": {
+            "title": "Do you take custom orders?",
+            "content": "<p>Yes! Share your story and inspiration via the contact form and Alison will design a bespoke piece.</p>"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/contact-form.liquid
+++ b/theme/arc-duality-theme/sections/contact-form.liquid
@@ -1,0 +1,69 @@
+<section class="section" id="ContactForm-{{ section.id }}">
+  <div class="wrapper">
+    <div class="section__header">
+      <h2 class="section__title">{{ section.settings.heading }}</h2>
+      {% if section.settings.subheading != blank %}
+        <p class="section__description">{{ section.settings.subheading }}</p>
+      {% endif %}
+    </div>
+
+    {% form 'contact', class: 'contact-form' %}
+      {% if form.posted_successfully? %}
+        <p class="notice">{{ 'sections.contact_form.success' | t }}</p>
+      {% elsif form.errors %}
+        <div class="notice" role="alert">
+          <ul>
+            {% for field in form.errors %}
+              <li>{{ field | capitalize }} – {{ form.errors.messages[field] }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <label for="ContactFormName-{{ section.id }}" class="visually-hidden">{{ 'sections.contact_form.name' | t }}</label>
+      <input id="ContactFormName-{{ section.id }}" type="text" name="contact[name]" placeholder="{{ 'sections.contact_form.name' | t }}" value="{{ form.name }}" required>
+
+      <label for="ContactFormEmail-{{ section.id }}" class="visually-hidden">{{ 'sections.contact_form.email' | t }}</label>
+      <input id="ContactFormEmail-{{ section.id }}" type="email" name="contact[email]" placeholder="{{ 'sections.contact_form.email' | t }}" value="{{ form.email }}" required>
+
+      <label for="ContactFormPhone-{{ section.id }}" class="visually-hidden">{{ 'sections.contact_form.phone' | t }}</label>
+      <input id="ContactFormPhone-{{ section.id }}" type="tel" name="contact[phone]" placeholder="{{ 'sections.contact_form.phone' | t }}" value="{{ form.phone }}">
+
+      <label for="ContactFormMessage-{{ section.id }}" class="visually-hidden">{{ 'sections.contact_form.message' | t }}</label>
+      <textarea id="ContactFormMessage-{{ section.id }}" name="contact[body]" rows="6" placeholder="{{ 'sections.contact_form.message' | t }}" required>{{ form.body }}</textarea>
+
+      <button type="submit">{{ section.settings.button_label }}</button>
+    {% endform %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Contact form",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Request a Custom Resin Creation"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Share your vision, occasion, and favourite colours—Alison will reply with ideas and next steps."
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Send message"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Contact form"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/featured-arc-grid.liquid
+++ b/theme/arc-duality-theme/sections/featured-arc-grid.liquid
@@ -1,0 +1,70 @@
+{% liquid
+  assign featured_collection = section.settings.collection
+  assign products_to_show = section.settings.products_to_show | default: 4
+%}
+
+<section class="section" id="FeaturedGrid-{{ section.id }}">
+  <div class="wrapper">
+    <div class="section__header">
+      <h2 class="section__title">{{ section.settings.heading }}</h2>
+      {% if section.settings.subheading != blank %}
+        <p class="section__description">{{ section.settings.subheading }}</p>
+      {% endif %}
+    </div>
+
+    {% if featured_collection and featured_collection.products_count > 0 %}
+      <div class="product-grid">
+        {% for product in featured_collection.products limit: products_to_show %}
+          {% render 'product-card', product: product, show_swatches: section.settings.show_swatches %}
+        {% endfor %}
+      </div>
+    {% else %}
+      <p>{{ 'sections.featured_arc_grid.empty' | t }}</p>
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "ARC Featured Grid",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Featured Resin Keepsakes"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Curated best-sellers chosen for their enchanting detail and heirloom charm."
+    },
+    {
+      "type": "collection",
+      "id": "collection",
+      "label": "Collection"
+    },
+    {
+      "type": "range",
+      "id": "products_to_show",
+      "label": "Products to show",
+      "min": 2,
+      "max": 12,
+      "step": 1,
+      "default": 4
+    },
+    {
+      "type": "checkbox",
+      "id": "show_swatches",
+      "label": "Show color swatches",
+      "default": true
+    }
+  ],
+  "presets": [
+    {
+      "name": "ARC Featured Grid"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/footer.liquid
+++ b/theme/arc-duality-theme/sections/footer.liquid
@@ -1,0 +1,153 @@
+<footer class="footer" role="contentinfo">
+  <div class="wrapper footer__inner">
+    <div class="footer__column">
+      <a href="{{ routes.root_url }}" class="footer__brand">
+        {% if settings.brand_logo != blank %}
+          <img
+            src="{{ settings.brand_logo | image_url: width: 200 }}"
+            alt="{{ 'sections.footer.logo_alt' | t: shop_name: shop.name }}"
+            width="96"
+            height="96"
+            loading="lazy">
+        {% else %}
+          <img
+            src="{{ 'arc-logo.png' | asset_url }}"
+            alt="{{ 'sections.footer.logo_alt' | t: shop_name: shop.name }}"
+            width="96"
+            height="96"
+            loading="lazy">
+        {% endif %}
+      </a>
+      <p>{{ section.settings.brand_blurb }}</p>
+      {% assign has_social = false %}
+      {% for block in section.blocks %}
+        {% if block.type == 'social' and block.settings.url != blank %}
+          {% assign has_social = true %}
+        {% endif %}
+      {% endfor %}
+      {% if has_social %}
+        <div class="footer__socials">
+          {% for block in section.blocks %}
+            {% if block.type == 'social' and block.settings.url != blank %}
+              <a href="{{ block.settings.url }}" target="_blank" rel="noopener" aria-label="{{ block.settings.label }}">
+                {{ block.settings.label }}
+              </a>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="footer__column">
+      <h3>{{ section.settings.shop_heading }}</h3>
+      <ul>
+        {% if section.settings.shop_menu %}
+          {% for link in section.settings.shop_menu.links %}
+            <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+          {% endfor %}
+        {% else %}
+          <li><a href="{{ routes.all_products_collection_url }}">{{ 'sections.footer.default_shop' | t }}</a></li>
+        {% endif %}
+      </ul>
+    </div>
+
+    <div class="footer__column">
+      <h3>{{ section.settings.policy_heading }}</h3>
+      <ul>
+        {% if section.settings.policy_menu %}
+          {% for link in section.settings.policy_menu.links %}
+            <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+          {% endfor %}
+        {% else %}
+          <li><a href="/pages/faq">{{ 'sections.footer.default_faq' | t }}</a></li>
+          <li><a href="/pages/terms">{{ 'sections.footer.default_terms' | t }}</a></li>
+          <li><a href="/pages/privacy">{{ 'sections.footer.default_privacy' | t }}</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+  <div class="wrapper footer__bottom">
+    <small>&copy; {{ 'now' | date: '%Y' }} {{ section.settings.footer_copyright | default: shop.name }}. {{ 'sections.footer.rights' | t }}</small>
+  </div>
+</footer>
+
+{% schema %}
+{
+  "name": "ARC Footer",
+  "settings": [
+    {
+      "type": "textarea",
+      "id": "brand_blurb",
+      "label": "Brand blurb",
+      "default": "Alison Resin Creations captures cherished stories in luminous resin art, each piece lovingly poured by hand."
+    },
+    {
+      "type": "text",
+      "id": "shop_heading",
+      "label": "Shop column heading",
+      "default": "Shop Alison Resin Creations"
+    },
+    {
+      "type": "link_list",
+      "id": "shop_menu",
+      "label": "Shop menu"
+    },
+    {
+      "type": "text",
+      "id": "policy_heading",
+      "label": "Policies column heading",
+      "default": "Need to Know"
+    },
+    {
+      "type": "link_list",
+      "id": "policy_menu",
+      "label": "Policy menu"
+    },
+    {
+      "type": "text",
+      "id": "footer_copyright",
+      "label": "Footer copyright text",
+      "default": "Alison Resin Creations"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "social",
+      "name": "Social link",
+      "settings": [
+        {
+          "type": "text",
+          "id": "label",
+          "label": "Label",
+          "default": "Instagram"
+        },
+        {
+          "type": "url",
+          "id": "url",
+          "label": "URL"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "ARC Footer",
+      "blocks": [
+        {
+          "type": "social",
+          "settings": {
+            "label": "Instagram"
+          }
+        },
+        {
+          "type": "social",
+          "settings": {
+            "label": "Facebook"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/gallery-media.liquid
+++ b/theme/arc-duality-theme/sections/gallery-media.liquid
@@ -1,0 +1,110 @@
+<section class="section section--surface" id="GalleryMedia-{{ section.id }}">
+  <div class="wrapper">
+    <div class="section__header">
+      <h2 class="section__title">{{ section.settings.heading }}</h2>
+      {% if section.settings.subheading != blank %}
+        <p class="section__description">{{ section.settings.subheading }}</p>
+      {% endif %}
+    </div>
+    <div class="gallery-media-grid">
+      {% for block in section.blocks %}
+        <div class="gallery-media-item" {{ block.shopify_attributes }}>
+          {% case block.type %}
+            {% when 'product' %}
+              {% assign product = block.settings.product %}
+              {% if product %}
+                <a href="{{ product.url }}" class="gallery-media-product">
+                  {% if product.featured_media %}
+                    {% assign gallery_alt = product.featured_media.alt | default: product.title %}
+                    <div class="gallery-media-thumb">
+                      {{ product.featured_media | image_url: width: 640 | image_tag: loading: 'lazy', alt: gallery_alt }}
+                    </div>
+                  {% endif %}
+                  <div class="gallery-media-caption">
+                    <h3>{{ product.title }}</h3>
+                    {% if product.price_varies %}
+                      <p>{{ product.price_min | money }} – {{ product.price_max | money }}</p>
+                    {% else %}
+                      <p>{{ product.price | money }}</p>
+                    {% endif %}
+                  </div>
+                </a>
+              {% endif %}
+            {% when 'video' %}
+              {% render 'media-video', video_url: block.settings.video_url, poster: block.settings.poster, caption: block.settings.caption %}
+          {% endcase %}
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "ARC Gallery Media",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Step Inside the ARC Gallery"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "See the luminous glow, suspended blooms, and storybook details that make each resin scene unforgettable."
+    }
+  ],
+  "blocks": [
+    {
+      "type": "product",
+      "name": "Product",
+      "settings": [
+        {
+          "type": "product",
+          "id": "product",
+          "label": "Product"
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "name": "Video",
+      "settings": [
+        {
+          "type": "text",
+          "id": "video_url",
+          "label": "Video URL",
+          "info": "Supports MP4 URLs or Shopify-hosted video file URLs."
+        },
+        {
+          "type": "image_picker",
+          "id": "poster",
+          "label": "Poster image"
+        },
+        {
+          "type": "text",
+          "id": "caption",
+          "label": "Caption",
+          "default": "Behind the scenes of a glowing resin village"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 8,
+  "presets": [
+    {
+      "name": "ARC Gallery Media",
+      "blocks": [
+        {
+          "type": "product"
+        },
+        {
+          "type": "video"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/header.liquid
+++ b/theme/arc-duality-theme/sections/header.liquid
@@ -1,0 +1,153 @@
+{% liquid
+  assign navigation_menu = section.settings.menu
+%}
+
+{% if section.settings.announcement_enable and section.settings.announcement_text != blank %}
+  <div class="announcement-bar" data-announcement data-announcement="{{ section.id }}">
+    <div class="wrapper">
+      <span>{{ section.settings.announcement_text }}</span>
+      {% if section.settings.announcement_dismissible %}
+        <button type="button" class="announcement-bar__dismiss" data-announcement-dismiss>{{ 'sections.header.announcement_dismiss' | t }}</button>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
+<header class="site-header">
+  <div class="wrapper site-header__inner">
+    <div class="site-header__branding">
+      <a href="{{ routes.root_url }}" class="site-header__logo" aria-label="{{ 'sections.header.home_link_label' | t }}">
+        {% if settings.brand_logo != blank %}
+          <img
+            src="{{ settings.brand_logo | image_url: width: 200 }}"
+            alt="{{ 'sections.header.logo_alt' | t: shop_name: shop.name }}"
+            width="96"
+            height="96"
+            loading="lazy">
+        {% else %}
+          <img
+            src="{{ 'arc-logo.png' | asset_url }}"
+            alt="{{ 'sections.header.logo_alt' | t: shop_name: shop.name }}"
+            width="96"
+            height="96"
+            loading="lazy">
+        {% endif %}
+      </a>
+      <div class="site-header__title-group">
+        <a href="{{ routes.root_url }}" class="site-header__title">{{ section.settings.store_name | default: shop.name }}</a>
+        {% if section.settings.tagline != blank %}
+          <p class="site-header__tagline">{{ section.settings.tagline }}</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <nav class="site-nav" role="navigation" aria-label="{{ 'sections.header.navigation_aria' | t }}">
+      {% if navigation_menu != blank %}
+        {% for link in navigation_menu.links %}
+          <a href="{{ link.url }}" {% if link.current %}aria-current="page"{% endif %}>{{ link.title }}</a>
+        {% endfor %}
+      {% else %}
+        <a href="{{ routes.root_url }}">{{ 'sections.header.nav_home' | t }}</a>
+        <a href="/pages/gallery">{{ 'sections.header.nav_gallery' | t }}</a>
+        <a href="{{ routes.all_products_collection_url }}">{{ 'sections.header.nav_shop' | t }}</a>
+        <a href="/pages/about">{{ 'sections.header.nav_about' | t }}</a>
+        <a href="/pages/faq">{{ 'sections.header.nav_faq' | t }}</a>
+        <a href="/pages/terms">{{ 'sections.header.nav_terms' | t }}</a>
+        <a href="/pages/privacy">{{ 'sections.header.nav_privacy' | t }}</a>
+        <a href="/pages/contact">{{ 'sections.header.nav_contact' | t }}</a>
+        <a href="{{ routes.cart_url }}">{{ 'sections.header.nav_cart' | t }}</a>
+      {% endif %}
+    </nav>
+
+    <div class="utility-actions">
+      {% if settings.enable_dark_mode %}
+        <button type="button"
+          class="theme-toggle"
+          data-theme-toggle
+          data-label-light="{{ 'sections.header.mode_light' | t }}"
+          data-label-dark="{{ 'sections.header.mode_dark' | t }}"
+          aria-pressed="false"
+          aria-label="{{ 'sections.header.mode_toggle' | t }}">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="currentColor" role="presentation">
+              <path d="M12 3a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 9a7 7 0 1 1-7-7 5 5 0 0 0 0 10 5 5 0 0 0 0-10 7 7 0 0 1 7 7Zm-7 9a1 1 0 0 1 1-1h1a1 1 0 1 1 0 2h-1a1 1 0 0 1-1-1Zm8-8a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM5 12a1 1 0 0 1-1 1H3a1 1 0 1 1 0-2h1a1 1 0 0 1 1 1Zm1.64 7.36a1 1 0 0 1 1.41 0l.7.7a1 1 0 1 1-1.41 1.42l-.7-.71a1 1 0 0 1 0-1.41Zm0-14.72a1 1 0 0 1 1.41 0l.7.7A1 1 0 0 1 7.34 7l-.7-.7a1 1 0 0 1 0-1.42Zm10.72 14.72a1 1 0 0 1 0 1.41l-.7.71a1 1 0 0 1-1.41-1.42l.7-.7a1 1 0 0 1 1.41 0Z" />
+            </svg>
+          </span>
+          <span data-theme-toggle-label>{{ 'sections.header.mode_dark' | t }}</span>
+        </button>
+      {% endif %}
+
+      {% if settings.enable_social_icons and (settings.social_instagram != blank or settings.social_facebook != blank or settings.social_tiktok != blank) %}
+        <div class="header-socials">
+          {% if settings.social_instagram != blank %}
+            <a href="{{ settings.social_instagram }}" target="_blank" rel="noopener" aria-label="Instagram">IG</a>
+          {% endif %}
+          {% if settings.social_facebook != blank %}
+            <a href="{{ settings.social_facebook }}" target="_blank" rel="noopener" aria-label="Facebook">FB</a>
+          {% endif %}
+          {% if settings.social_tiktok != blank %}
+            <a href="{{ settings.social_tiktok }}" target="_blank" rel="noopener" aria-label="TikTok">TT</a>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      <a href="{{ routes.cart_url }}" class="cart-link" aria-label="{{ 'sections.header.cart' | t }}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"></path>
+          <path d="M6 6 4.5 3H2" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="9" cy="20" r="1"></circle>
+          <circle cx="18" cy="20" r="1"></circle>
+        </svg>
+        <span class="cart-count" data-cart-count hidden>0</span>
+      </a>
+    </div>
+  </div>
+</header>
+
+{% schema %}
+{
+  "name": "ARC Header",
+  "settings": [
+    {
+      "type": "text",
+      "id": "store_name",
+      "label": "Store name",
+      "default": "Alison Resin Creations"
+    },
+    {
+      "type": "text",
+      "id": "tagline",
+      "label": "Tagline",
+      "default": "Resin artistry for whimsical hearts"
+    },
+    {
+      "type": "link_list",
+      "id": "menu",
+      "label": "Navigation menu"
+    },
+    {
+      "type": "checkbox",
+      "id": "announcement_enable",
+      "label": "Show announcement",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "announcement_text",
+      "label": "Announcement text",
+      "default": "Free UK shipping on orders over £75"
+    },
+    {
+      "type": "checkbox",
+      "id": "announcement_dismissible",
+      "label": "Allow dismissal",
+      "default": true
+    }
+  ],
+  "presets": [
+    {
+      "name": "ARC Header"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/hero-arc.liquid
+++ b/theme/arc-duality-theme/sections/hero-arc.liquid
@@ -1,0 +1,72 @@
+<section class="section section--surface hero" id="Hero-{{ section.id }}">
+  <div class="wrapper">
+    <div class="hero">
+      {% if section.settings.notice != blank %}
+        <div class="notice">{{ section.settings.notice }}</div>
+      {% endif %}
+      <div class="hero__content">
+        <h1 class="hero__heading">{{ section.settings.heading }}</h1>
+        <p class="hero__description">{{ section.settings.body }}</p>
+        <div class="hero__actions">
+          <a class="primary" href="{{ section.settings.primary_link }}">{{ section.settings.primary_label }}</a>
+          <a class="secondary" href="{{ section.settings.secondary_link }}">{{ section.settings.secondary_label }}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "ARC Hero",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Whimsical Resin Worlds, Poured with Heart"
+    },
+    {
+      "type": "textarea",
+      "id": "body",
+      "label": "Supporting text",
+      "default": "Discover hand-crafted resin keepsakes that shimmer with storybook details and the warmth of artisan craftsmanship."
+    },
+    {
+      "type": "text",
+      "id": "primary_label",
+      "label": "Primary button label",
+      "default": "Shop the Collection"
+    },
+    {
+      "type": "url",
+      "id": "primary_link",
+      "label": "Primary button link",
+      "default": "/collections/all"
+    },
+    {
+      "type": "text",
+      "id": "secondary_label",
+      "label": "Secondary button label",
+      "default": "Explore the Gallery"
+    },
+    {
+      "type": "url",
+      "id": "secondary_link",
+      "label": "Secondary button link",
+      "default": "/pages/gallery"
+    },
+    {
+      "type": "text",
+      "id": "notice",
+      "label": "Optional notice",
+      "default": "Custom commissions open for Spring gifting!"
+    }
+  ],
+  "presets": [
+    {
+      "name": "ARC Hero"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/main-collection.liquid
+++ b/theme/arc-duality-theme/sections/main-collection.liquid
@@ -1,0 +1,63 @@
+<section class="section collection" id="Collection-{{ section.id }}">
+  <div class="wrapper collection__inner">
+    <header class="collection__header">
+      <h1 class="collection__title">{{ collection.title }}</h1>
+      {% if collection.description != blank %}
+        <div class="collection__description">{{ collection.description }}</div>
+      {% endif %}
+    </header>
+
+    {% if collection.all_tags.size > 0 %}
+      <div class="collection__filters">
+        <div class="collection__filter-group">
+          <span class="collection__filter-label">{{ 'sections.main_collection.filter_tags' | t }}</span>
+          <ul>
+            {% for tag in collection.all_tags %}
+              <li>{{ tag | link_to_tag: tag }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% assign has_color_tags = false %}
+        {% for tag in collection.all_tags %}
+          {% assign tag_down = tag | downcase %}
+          {% if tag_down contains 'colour' or tag_down contains 'color' %}
+            {% assign has_color_tags = true %}
+          {% endif %}
+        {% endfor %}
+        {% if has_color_tags %}
+          <div class="collection__filter-group">
+            <span class="collection__filter-label">{{ 'sections.main_collection.filter_colors' | t }}</span>
+            <ul>
+              {% for tag in collection.all_tags %}
+                {% assign tag_down = tag | downcase %}
+                {% if tag_down contains 'colour' or tag_down contains 'color' %}
+                  <li>{{ tag | link_to_tag: tag }}</li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    <div class="product-grid">
+      {% for product in collection.products %}
+        {% render 'product-card', product: product, show_swatches: true %}
+      {% else %}
+        <p>{{ 'sections.main_collection.empty' | t }}</p>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Main collection",
+  "settings": [],
+  "presets": [
+    {
+      "name": "Collection"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/main-product.liquid
+++ b/theme/arc-duality-theme/sections/main-product.liquid
@@ -1,0 +1,164 @@
+<section class="section product" id="Product-{{ section.id }}">
+  <div class="wrapper product__inner">
+    <div class="product__gallery">
+      {% if product.media.size > 0 %}
+        {% for media in product.media %}
+          <div class="product__media" data-media-type="{{ media.media_type }}">
+            {{ media | media_tag }}
+          </div>
+        {% endfor %}
+      {% endif %}
+    </div>
+
+    <div class="product__details">
+      <h1 class="product__title">{{ product.title }}</h1>
+      <div class="product__price">
+        {% if product.price_varies %}
+          {{ product.price_min | money }} – {{ product.price_max | money }}
+        {% else %}
+          {{ product.price | money }}
+        {% endif %}
+      </div>
+
+      {% if product.metafields.custom.quote != blank %}
+        <blockquote class="product__quote">“{{ product.metafields.custom.quote }}”</blockquote>
+      {% endif %}
+
+      {% form 'product', product, class: 'product__form' %}
+        {% unless product.has_only_default_variant %}
+          {% for option in product.options_with_values %}
+            <label for="Option-{{ section.id }}-{{ forloop.index }}">{{ option.name }}</label>
+            <select id="Option-{{ section.id }}-{{ forloop.index }}" name="options[{{ option.name }}]">
+              {% for value in option.values %}
+                <option value="{{ value }}" {% if option.selected_value == value %}selected{% endif %}>{{ value }}</option>
+              {% endfor %}
+            </select>
+          {% endfor %}
+        {% endunless %}
+
+        <label for="Quantity-{{ section.id }}" class="visually-hidden">{{ 'products.product.quantity' | t }}</label>
+        <input id="Quantity-{{ section.id }}" type="number" name="quantity" min="1" value="1">
+
+        <button type="submit" name="add" {% unless product.available %}disabled{% endunless %}>
+          {% if product.available %}
+            {{ 'products.product.add_to_cart' | t }}
+          {% else %}
+            {{ 'products.product.sold_out' | t }}
+          {% endif %}
+        </button>
+      {% endform %}
+
+      <div class="product__share">
+        <p>{{ 'sections.main_product.share_label' | t }}</p>
+        <ul>
+          <li><a href="https://www.facebook.com/sharer/sharer.php?u={{ product.url | url_escape }}" target="_blank" rel="noopener">Facebook</a></li>
+          <li><a href="https://twitter.com/intent/tweet?url={{ product.url | url_escape }}&text={{ product.title | url_escape }}" target="_blank" rel="noopener">Twitter</a></li>
+          <li><a href="mailto:?subject={{ product.title | url_escape }}&body={{ product.url | url_escape }}">Email</a></li>
+        </ul>
+      </div>
+
+      {% if section.blocks.size > 0 %}
+        <div class="product__extra">
+          {% for block in section.blocks %}
+            <div class="product__extra-block" {{ block.shopify_attributes }}>
+              {% case block.type %}
+                {% when 'video' %}
+                  {% render 'media-video', video_url: block.settings.video_url, poster: block.settings.poster, caption: block.settings.caption %}
+                {% when 'text' %}
+                  <div class="product__text-block">
+                    <h3>{{ block.settings.title }}</h3>
+                    <div>{{ block.settings.content }}</div>
+                  </div>
+                {% when 'collapsible' %}
+                  <details>
+                    <summary>{{ block.settings.title }}</summary>
+                    <div>{{ block.settings.content }}</div>
+                  </details>
+              {% endcase %}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Main product",
+  "settings": [],
+  "blocks": [
+    {
+      "type": "video",
+      "name": "Video",
+      "settings": [
+        {
+          "type": "text",
+          "id": "video_url",
+          "label": "Video URL"
+        },
+        {
+          "type": "image_picker",
+          "id": "poster",
+          "label": "Poster"
+        },
+        {
+          "type": "text",
+          "id": "caption",
+          "label": "Caption"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "name": "Text block",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "Care instructions"
+        },
+        {
+          "type": "richtext",
+          "id": "content",
+          "label": "Content",
+          "default": "<p>Gently dust with a soft cloth and keep away from direct sunlight to preserve clarity.</p>"
+        }
+      ]
+    },
+    {
+      "type": "collapsible",
+      "name": "Collapsible",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "Shipping & returns"
+        },
+        {
+          "type": "richtext",
+          "id": "content",
+          "label": "Content",
+          "default": "<p>Orders dispatch within 5-7 working days. Contact us for rush arrangements.</p>"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "Product details",
+      "blocks": [
+        {
+          "type": "text"
+        },
+        {
+          "type": "collapsible"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/rich-text.liquid
+++ b/theme/arc-duality-theme/sections/rich-text.liquid
@@ -1,0 +1,35 @@
+<section class="section" id="RichText-{{ section.id }}">
+  <div class="wrapper">
+    <div class="section__header">
+      <h2 class="section__title">{{ section.settings.heading }}</h2>
+      {% if section.settings.content != blank %}
+        <div class="rich-text">{{ section.settings.content }}</div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Rich text",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "A note from Alison"
+    },
+    {
+      "type": "richtext",
+      "id": "content",
+      "label": "Content",
+      "default": "<p>Use this space to share your story, your process, and the love poured into every resin creation.</p>"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Rich text"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/sections/story-highlights.liquid
+++ b/theme/arc-duality-theme/sections/story-highlights.liquid
@@ -1,0 +1,106 @@
+<section class="section" id="StoryHighlights-{{ section.id }}">
+  <div class="wrapper">
+    <div class="section__header">
+      <h2 class="section__title">{{ section.settings.heading }}</h2>
+      {% if section.settings.subheading != blank %}
+        <p class="section__description">{{ section.settings.subheading }}</p>
+      {% endif %}
+    </div>
+    <div class="story-highlights">
+      {% for block in section.blocks %}
+        <article class="story-highlight" {{ block.shopify_attributes }}>
+          {% if block.settings.icon_image %}
+            <img src="{{ block.settings.icon_image | image_url: width: 96 }}" alt="" class="story-highlight__icon" loading="lazy">
+          {% elsif block.settings.icon_text != blank %}
+            <span class="story-highlight__icon" aria-hidden="true">{{ block.settings.icon_text }}</span>
+          {% endif %}
+          <h3>{{ block.settings.title }}</h3>
+          <p>{{ block.settings.text }}</p>
+        </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "ARC Story Highlights",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Why Collectors Love ARC"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Each resin scene is carefully layered with colour, light, and bespoke storytelling touches."
+    }
+  ],
+  "blocks": [
+    {
+      "type": "feature",
+      "name": "Feature",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "icon_image",
+          "label": "Icon image"
+        },
+        {
+          "type": "text",
+          "id": "icon_text",
+          "label": "Icon fallback (emoji or letter)",
+          "default": "✨"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "Hand-Poured Quality"
+        },
+        {
+          "type": "textarea",
+          "id": "text",
+          "label": "Description",
+          "default": "Every piece is poured, sanded, and finished by hand for a smooth, heirloom-grade shine."
+        }
+      ]
+    }
+  ],
+  "max_blocks": 3,
+  "presets": [
+    {
+      "name": "ARC Story Highlights",
+      "blocks": [
+        {
+          "type": "feature",
+          "settings": {
+            "title": "Hand-Poured Quality",
+            "text": "Every piece is poured, sanded, and finished by hand for a smooth, heirloom-grade shine.",
+            "icon_text": "👐"
+          }
+        },
+        {
+          "type": "feature",
+          "settings": {
+            "title": "Storybook Charm",
+            "text": "Miniature scenes glow with fairy lights, glittering skies, and imaginative woodland friends.",
+            "icon_text": "📖"
+          }
+        },
+        {
+          "type": "feature",
+          "settings": {
+            "title": "Custom-Ready Details",
+            "text": "Collaborate on colour palettes, quotes, and special keepsakes that honour your memories.",
+            "icon_text": "🎨"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/theme/arc-duality-theme/snippets/media-video.liquid
+++ b/theme/arc-duality-theme/snippets/media-video.liquid
@@ -1,0 +1,11 @@
+{% if video_url != blank %}
+  <figure class="video-wrapper">
+    <video controls playsinline preload="metadata" {% if poster %}poster="{{ poster | image_url: width: 1200 }}"{% endif %}>
+      <source src="{{ video_url }}" type="video/mp4">
+      {{ 'snippets.media_video.fallback' | t }}
+    </video>
+    {% if caption %}
+      <figcaption>{{ caption }}</figcaption>
+    {% endif %}
+  </figure>
+{% endif %}

--- a/theme/arc-duality-theme/snippets/product-card.liquid
+++ b/theme/arc-duality-theme/snippets/product-card.liquid
@@ -1,0 +1,55 @@
+{% liquid
+  assign first_variant = product.selected_or_first_available_variant
+  assign featured_media = product.featured_media
+  if featured_media
+    assign featured_alt = featured_media.alt | default: product.title
+  endif
+%}
+
+<div class="product-card">
+  <a href="{{ product.url }}" class="product-card__media" aria-label="{{ product.title }}">
+    {% if featured_media %}
+      {{ featured_media | image_url: width: 600 | image_tag: loading: 'lazy', alt: featured_alt }}
+    {% else %}
+      <div class="product-card__placeholder">{{ 'products.product.no_image' | t }}</div>
+    {% endif %}
+  </a>
+  <div class="product-card__info">
+    <h3 class="product-card__title">{{ product.title }}</h3>
+    <p class="product-card__price">
+      {% if product.price_varies %}
+        {{ product.price_min | money }} – {{ product.price_max | money }}
+      {% else %}
+        {{ product.price | money }}
+      {% endif %}
+    </p>
+
+    {% if show_swatches %}
+      {% for option in product.options_with_values %}
+        {% assign option_name = option.name | downcase %}
+        {% if option_name contains 'color' or option_name contains 'colour' %}
+          <div class="swatch-list" aria-label="{{ option.name }}">
+            {% for value in option.values limit: 6 %}
+              <span class="swatch" title="{{ value }}" style="background-color: {{ value | escape }};"></span>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    <form method="post" action="{{ routes.cart_add_url }}" class="product-card__form">
+      {% if first_variant %}
+        <input type="hidden" name="id" value="{{ first_variant.id }}">
+        <button type="submit" {% unless first_variant.available %}disabled{% endunless %}>
+          {% if first_variant.available %}
+            {{ 'products.product.add_to_cart' | t }}
+          {% else %}
+            {{ 'products.product.sold_out' | t }}
+          {% endif %}
+        </button>
+      {% else %}
+        <button type="button" disabled>{{ 'products.product.sold_out' | t }}</button>
+      {% endif %}
+    </form>
+  </div>
+</div>

--- a/theme/arc-duality-theme/templates/collection.json
+++ b/theme/arc-duality-theme/templates/collection.json
@@ -1,0 +1,11 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-collection",
+      "settings": {}
+    }
+  },
+  "order": [
+    "main"
+  ]
+}

--- a/theme/arc-duality-theme/templates/index.json
+++ b/theme/arc-duality-theme/templates/index.json
@@ -1,0 +1,46 @@
+{
+  "sections": {
+    "hero": {
+      "type": "hero-arc",
+      "settings": {
+        "heading": "Whimsical Resin Worlds, Poured with Heart",
+        "body": "Discover hand-crafted resin keepsakes that shimmer with storybook details, fairy lights, and the warmth of artisan craftsmanship.",
+        "primary_label": "Shop Resin Keepsakes",
+        "primary_link": "/collections/all",
+        "secondary_label": "Visit the Gallery",
+        "secondary_link": "/pages/gallery",
+        "notice": "Limited-edition spring villages now pouring!"
+      }
+    },
+    "featured": {
+      "type": "featured-arc-grid",
+      "settings": {
+        "heading": "Collector Favourites",
+        "subheading": "A curated look at glowing house scenes, storybook balloons, and bespoke keepsakes currently enchanting our community.",
+        "collection": "",
+        "products_to_show": 4,
+        "show_swatches": true
+      }
+    },
+    "stories": {
+      "type": "story-highlights",
+      "settings": {
+        "heading": "A Duality of Craft and Story",
+        "subheading": "Balancing luminous resin artistry with heartfelt narratives that make every ARC piece uniquely yours."
+      }
+    },
+    "gallery": {
+      "type": "gallery-media",
+      "settings": {
+        "heading": "Peek Into the ARC Studio",
+        "subheading": "From twinkling villages to balloon adventures, explore media that captures Alison's world-building in resin."
+      }
+    }
+  },
+  "order": [
+    "hero",
+    "featured",
+    "stories",
+    "gallery"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.about.json
+++ b/theme/arc-duality-theme/templates/page.about.json
@@ -1,0 +1,22 @@
+{
+  "sections": {
+    "story": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Meet Alison",
+        "content": "<p>From the first glittering pour to the final hand-painted flourish, Alison crafts dual worlds where comfort and wonder co-exist. Every ARC creation is an invitation to pause, dream, and cherish.</p><p>In her Kent studio, Alison blends artisan techniques with bespoke storytelling to create heirloom keepsakes that glow from within.</p>"
+      }
+    },
+    "values": {
+      "type": "story-highlights",
+      "settings": {
+        "heading": "Our Crafting Pillars",
+        "subheading": "Rooted in careful detail, collaborative design, and pure-hearted whimsy."
+      }
+    }
+  },
+  "order": [
+    "story",
+    "values"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.contact.json
+++ b/theme/arc-duality-theme/templates/page.contact.json
@@ -1,0 +1,23 @@
+{
+  "sections": {
+    "intro": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Contact Alison",
+        "content": "<p>We love hearing from fellow dreamers. Share your questions, custom requests, or kind words below.</p>"
+      }
+    },
+    "form": {
+      "type": "contact-form",
+      "settings": {
+        "heading": "Send a Message",
+        "subheading": "Tell us about your occasion, style inspiration, and any personal touches you'd like to include.",
+        "button_label": "Send message"
+      }
+    }
+  },
+  "order": [
+    "intro",
+    "form"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.faq.json
+++ b/theme/arc-duality-theme/templates/page.faq.json
@@ -1,0 +1,49 @@
+{
+  "sections": {
+    "intro": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Frequently Asked Questions",
+        "content": "<p>Here you'll find details about lead times, custom commissions, care instructions, and more.</p>"
+      }
+    },
+    "faq": {
+      "type": "collapsible-content",
+      "settings": {
+        "heading": "FAQs"
+      },
+      "blocks": {
+        "question-1": {
+          "type": "item",
+          "settings": {
+            "title": "How long does a custom piece take?",
+            "content": "<p>Custom orders usually take 3-4 weeks, allowing time for sketching, layered pours, curing, and finishing details.</p>"
+          }
+        },
+        "question-2": {
+          "type": "item",
+          "settings": {
+            "title": "Do the lights include batteries?",
+            "content": "<p>Yes! Your glowing house scenes arrive with replaceable batteries and simple on/off switches.</p>"
+          }
+        },
+        "question-3": {
+          "type": "item",
+          "settings": {
+            "title": "Can I request a specific quote or colour palette?",
+            "content": "<p>Absolutely—share your ideas via the contact form and Alison will confirm the possibilities.</p>"
+          }
+        }
+      },
+      "block_order": [
+        "question-1",
+        "question-2",
+        "question-3"
+      ]
+    }
+  },
+  "order": [
+    "intro",
+    "faq"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.gallery.json
+++ b/theme/arc-duality-theme/templates/page.gallery.json
@@ -1,0 +1,22 @@
+{
+  "sections": {
+    "intro": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Gallery of Resin Whimsy",
+        "content": "<p>Explore a curated gallery of Alison's favourite resin pours: glowing house scenes, floating balloons, and storybook creatures that bring smiles to every shelf.</p>"
+      }
+    },
+    "media": {
+      "type": "gallery-media",
+      "settings": {
+        "heading": "Browse Featured Moments",
+        "subheading": "Swap blocks to spotlight seasonal launches, best-sellers, or the latest bespoke commissions."
+      }
+    }
+  },
+  "order": [
+    "intro",
+    "media"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.privacy.json
+++ b/theme/arc-duality-theme/templates/page.privacy.json
@@ -1,0 +1,14 @@
+{
+  "sections": {
+    "privacy": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Privacy Policy",
+        "content": "<p>Share how you collect, store, and protect customer information. Update this placeholder text with your official privacy policy.</p>"
+      }
+    }
+  },
+  "order": [
+    "privacy"
+  ]
+}

--- a/theme/arc-duality-theme/templates/page.terms.json
+++ b/theme/arc-duality-theme/templates/page.terms.json
@@ -1,0 +1,14 @@
+{
+  "sections": {
+    "policies": {
+      "type": "rich-text",
+      "settings": {
+        "heading": "Terms & Conditions",
+        "content": "<p>Outline your purchase terms, payment policies, shipping details, and cancellation process here. Replace this copy with your official store policies.</p>"
+      }
+    }
+  },
+  "order": [
+    "policies"
+  ]
+}

--- a/theme/arc-duality-theme/templates/product.json
+++ b/theme/arc-duality-theme/templates/product.json
@@ -1,0 +1,31 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "settings": {},
+      "blocks": {
+        "text": {
+          "type": "text",
+          "settings": {
+            "title": "Crafted with storybook charm",
+            "content": "<p>Each ARC piece is layered with shimmering pigments, fairy lights, and hand-painted accents for a one-of-a-kind heirloom.</p>"
+          }
+        },
+        "details": {
+          "type": "collapsible",
+          "settings": {
+            "title": "Shipping & turnaround",
+            "content": "<p>Handmade to order in 3-4 weeks. Need it sooner? Contact us and we'll see how we can help.</p>"
+          }
+        }
+      },
+      "block_order": [
+        "text",
+        "details"
+      ]
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- remove the pre-packaged `arc-logo.png` from the theme assets so the PR stays binary-free
- update header and footer snippets to respect the configurable brand logo and fall back to the ARC asset path
- document the required copy step before zipping so the logo ships with the production archive

## Testing
- not run (theme asset/documentation updates)

------
https://chatgpt.com/codex/tasks/task_e_68e2724bec8c832db802be61fcdc39ad